### PR TITLE
Adding validation for char/boolean tag value size

### DIFF
--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/ir/Entry.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/ir/Entry.java
@@ -219,6 +219,11 @@ public final class Entry
             return this instanceof Field && ((Field)this).isEnum();
         }
 
+        default boolean isCharOrBooleanBasedField()
+        {
+            return this instanceof Field && ((Field)this).isCharOrBooleanBasedField();
+        }
+
         String name();
     }
 }

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/ir/Field.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/ir/Field.java
@@ -103,6 +103,12 @@ public final class Field implements Element
         return !values.isEmpty();
     }
 
+    @Override
+    public boolean isCharOrBooleanBasedField()
+    {
+        return type.isCharBased || type.isBooleanBased;
+    }
+
     public boolean hasSharedSometimesEnumClash()
     {
         return hasSharedSometimesEnumClash;
@@ -180,7 +186,7 @@ public final class Field implements Element
         XMLDATA(false, false, false, false, false),
 
         // Boolean types
-        BOOLEAN(false, false, false, false, false),
+        BOOLEAN(false, false, false, false, false, true),
 
         UTCTIMESTAMP(true, false, false, false, false), // YYYYMMDD-HH:MM:SS or YYYYMMDD-HH:MM:SS.sss
         UTCTIMEONLY(true, false, false, false, false), // HH:MM:SS or HH:MM:SS.sss
@@ -195,6 +201,24 @@ public final class Field implements Element
         private final boolean isFloatBased;
         private final boolean isMultiValue;
         private final boolean isCharBased;
+        private final boolean isBooleanBased;
+
+        Type(
+            final boolean isStringBased,
+            final boolean isIntBased,
+            final boolean isFloatBased,
+            final boolean isMultiValue,
+            final boolean isCharBased,
+            final boolean isBooleanBased
+        )
+        {
+            this.isStringBased = isStringBased;
+            this.isIntBased = isIntBased;
+            this.isFloatBased = isFloatBased;
+            this.isMultiValue = isMultiValue;
+            this.isCharBased = isCharBased;
+            this.isBooleanBased = isBooleanBased;
+        }
 
         Type(
             final boolean isStringBased,
@@ -204,11 +228,7 @@ public final class Field implements Element
             final boolean isCharBased
         )
         {
-            this.isStringBased = isStringBased;
-            this.isIntBased = isIntBased;
-            this.isFloatBased = isFloatBased;
-            this.isMultiValue = isMultiValue;
-            this.isCharBased = isCharBased;
+            this(isStringBased, isIntBased, isFloatBased, isMultiValue, isCharBased, false);
         }
 
         public boolean isStringBased()
@@ -229,6 +249,11 @@ public final class Field implements Element
         public boolean isCharBased()
         {
             return isCharBased;
+        }
+
+        public boolean isCharOrBooleanBased()
+        {
+            return isCharBased || isBooleanBased;
         }
 
         public boolean isDataBased()

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/ExampleDictionary.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/ExampleDictionary.java
@@ -355,6 +355,22 @@ public final class ExampleDictionary
         "8=FIX.4.4\0019=61\00135=0\001115=abc\001116=2\001117=1.1" +
         "\001132=a b\001127=19700101-00:00:00.001\00110=225\001";
 
+    public static final String INCORRECT_BOOLEAN_VALUE_MESSAGE =
+        "8=FIX.4.4\0019=61\00135=0\001115=abc\001116=2\001117=1.1" +
+        "\001118=YY\001127=19700101-00:00:00.001\00110=225\001";
+
+    public static final String INCORRECT_SIZE_NO_ENUM_CHAR_VALUE_MESSAGE =
+        "8=FIX.4.4\0019=61\00135=0\001115=abc\001116=2\001117=1.1" +
+        "\001144=ab\001127=19700101-00:00:00.001\00110=225\001";
+
+    public static final String INCORRECT_SIZE_CHAR_VALUE_MESSAGE =
+        "8=FIX.4.4\0019=61\00135=0\001115=abc\001116=2\001117=1.1" +
+        "\001128=ab\001127=19700101-00:00:00.001\00110=225\001";
+
+    public static final String INCORRECT_SIZE_2_CHAR_VALUE_MESSAGE =
+        "8=FIX.4.4\0019=61\00135=0\001115=abc\001116=2\001117=1.1" +
+        "\001128=z\001127=19700101-00:00:00.001\00110=225\001";
+
     public static final String MULTI_CHAR_VALUE_NO_ENUM_MESSAGE =
         "8=FIX.4.4\0019=65\00135=0\001115=abc\001116=2\001117=1.1" +
         "\001134=a b z f\001127=19700101-00:00:00.001\00110=007\001";
@@ -553,6 +569,7 @@ public final class ExampleDictionary
         final Field booleanField = registerField(messageEgFields, 118, "BooleanField", Type.BOOLEAN);
         final Field dataField = registerField(messageEgFields, 119, "DataField", Type.DATA);
         final Field someTime = registerField(messageEgFields, 127, "SomeTimeField", Type.UTCTIMESTAMP);
+        final Field charNoEnumField = registerField(messageEgFields, 144, "CharNoEnumField", Type.CHAR);
         final Field charField = registerField(messageEgFields, 128, "CharField", Type.CHAR)
             .addValue("a", "One")
             .addValue("b", "Two");
@@ -622,6 +639,7 @@ public final class ExampleDictionary
         heartbeat.optionalEntry(dataFieldLength);
         heartbeat.optionalEntry(dataField);
         heartbeat.optionalEntry(charField);
+        heartbeat.optionalEntry(charNoEnumField);
         heartbeat.optionalEntry(multiCharField);
         heartbeat.optionalEntry(multiValStringField);
         heartbeat.optionalEntry(multiStringValField);

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/AbstractDecoderGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/AbstractDecoderGeneratorTest.java
@@ -1406,6 +1406,56 @@ public abstract class AbstractDecoderGeneratorTest
     }
 
     @Test
+    public void decodesInvalidSizeBooleanValueWithNoValidation() throws Exception
+    {
+        final Decoder decoder = decodeHeartbeatWithoutValidation(INCORRECT_BOOLEAN_VALUE_MESSAGE);
+        assertEquals(true, getBooleanField(decoder));
+        assertArrayEquals(new char[]{'Y', 'Y'}, getChars(decoder, "booleanFieldAsChars"));
+
+        assertValid(decoder);
+    }
+
+    @Test
+    public void decodesInvalidSizeBooleanValue() throws Exception
+    {
+        final Decoder decoder = decodeHeartbeat(INCORRECT_BOOLEAN_VALUE_MESSAGE);
+        assertEquals(true, getBooleanField(decoder));
+        assertArrayEquals(new char[]{'Y', 'Y'}, getChars(decoder, "booleanFieldAsChars"));
+
+        assertInvalid(decoder, 5, 118);
+    }
+
+    @Test
+    public void decodesInvalidSizeNoEnumCharValue() throws Exception
+    {
+        final Decoder decoder = decodeHeartbeat(INCORRECT_SIZE_NO_ENUM_CHAR_VALUE_MESSAGE);
+        assertEquals('a', getChar(decoder, "charNoEnumField"));
+        assertArrayEquals(new char[]{'a', 'b'}, getChars(decoder, "charNoEnumFieldAsChars"));
+
+        assertInvalid(decoder, 5, 144);
+    }
+
+    @Test
+    public void decodesInvalidSizeCharValue() throws Exception
+    {
+        final Decoder decoder = decodeHeartbeat(INCORRECT_SIZE_CHAR_VALUE_MESSAGE);
+        assertEquals('a', getCharField(decoder));
+        assertArrayEquals(new char[]{'a', 'b'}, getChars(decoder, "charFieldAsChars"));
+
+        assertInvalid(decoder, 5, 128);
+    }
+
+    @Test
+    public void decodesInvalidCharValue() throws Exception
+    {
+        final Decoder decoder = decodeHeartbeat(INCORRECT_SIZE_2_CHAR_VALUE_MESSAGE);
+        assertEquals('z', getCharField(decoder));
+        assertArrayEquals(new char[]{'z'}, getChars(decoder, "charFieldAsChars"));
+
+        assertInvalid(decoder, 5, 128);
+    }
+
+    @Test
     public void doesNotValidateIfNoEnumValuesPresent() throws Exception
     {
         final Decoder decoder = decodeHeartbeat(MULTI_CHAR_VALUE_NO_ENUM_MESSAGE);
@@ -1685,6 +1735,11 @@ public abstract class AbstractDecoderGeneratorTest
     private char[] getMultiCharField(final Decoder decoder) throws Exception
     {
         return getChars(decoder, "multiCharField");
+    }
+
+    private char getCharField(final Decoder decoder) throws Exception
+    {
+        return getChar(decoder, "charField");
     }
 
     private char[] getMultiCharNoEnumField(final Decoder decoder) throws Exception


### PR DESCRIPTION
This change aims to detect a validation error after parsing a FIX message with a char/boolean tag containing more than 1 character.
This fix will make `decoder.validate` to return `false` and 
```
rejectReason = 5
invalidTagId = <tag number where the error occurred>
```

Example: 
1. Given tag 31 is CHAR and name is myTag
2. Given message where "31=aa"
3. Then the following will happen:
4. `decoder.validate() = false`
5. `decoder.rejectReason = 5`
6. `decoder.invalidTagId = 31`
7. `decoder.myTag() = 'a'`
8. `decoder.myTagAsChars() = ['a', 'a']`