### PR TITLE
Resend Request Controller Overridden Begin Seq No

### DIFF
--- a/artio-codecs/src/main/resources/uk/co/real_logic/artio/messages/message-schema.xml
+++ b/artio-codecs/src/main/resources/uk/co/real_logic/artio/messages/message-schema.xml
@@ -2,7 +2,7 @@
 <sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
                    package="uk.co.real_logic.artio.messages"
                    id="666"
-                   version="26"
+                   version="27"
                    semanticVersion="0.2"
                    description="Internal messaging format used by the FIX Gateway"
                    byteOrder="littleEndian">
@@ -680,6 +680,7 @@
         <field name="endSequenceNumber" id="4" type="uint32"/>
         <field name="SequenceIndex" id="5" type="int32"/>
         <field name="correlationId" id="7" type="CorrelationId" sinceVersion="23"/>
+        <field name="overriddenBeginSequenceNumber" id="8" type="uint32" sinceVersion="27"/>
         <data name="body" id="6" type="AsciiString"/>
     </sbe:message>
 

--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/logger/EnqueuedReplay.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/logger/EnqueuedReplay.java
@@ -25,6 +25,7 @@ public class EnqueuedReplay
     private final long beginSeqNo;
     private final long endSeqNo;
     private final int sequenceIndex;
+    private final long overriddenBeginSeqNo;
     private final AsciiBuffer asciiBuffer;
 
     public EnqueuedReplay(
@@ -33,6 +34,7 @@ public class EnqueuedReplay
         final long correlationId, final long beginSeqNo,
         final long endSeqNo,
         final int sequenceIndex,
+        final long overriddenBeginSeqNo,
         final AsciiBuffer asciiBuffer)
     {
 
@@ -42,6 +44,7 @@ public class EnqueuedReplay
         this.beginSeqNo = beginSeqNo;
         this.endSeqNo = endSeqNo;
         this.sequenceIndex = sequenceIndex;
+        this.overriddenBeginSeqNo = overriddenBeginSeqNo;
         this.asciiBuffer = asciiBuffer;
     }
 
@@ -75,6 +78,11 @@ public class EnqueuedReplay
         return correlationId;
     }
 
+    public long overriddenBeginSeqNo()
+    {
+        return overriddenBeginSeqNo;
+    }
+
     public String toString()
     {
         return "EnqueuedReplay{" +
@@ -84,6 +92,7 @@ public class EnqueuedReplay
             ", beginSeqNo=" + beginSeqNo +
             ", endSeqNo=" + endSeqNo +
             ", sequenceIndex=" + sequenceIndex +
+            ", overriddenBeginSeqNo=" + overriddenBeginSeqNo +
             ", asciiBuffer=" + asciiBuffer.getAscii(0, asciiBuffer.capacity()) +
             '}';
     }

--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/logger/FixPReplayerSession.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/logger/FixPReplayerSession.java
@@ -34,6 +34,7 @@ import uk.co.real_logic.artio.messages.FixPMessageDecoder;
 import uk.co.real_logic.artio.messages.FixPMessageEncoder;
 import uk.co.real_logic.artio.messages.MessageHeaderEncoder;
 
+import static uk.co.real_logic.artio.LogTag.REPLAY;
 import static uk.co.real_logic.artio.LogTag.REPLAY_ATTEMPT;
 import static uk.co.real_logic.artio.fixp.AbstractFixPParser.FIXP_MESSAGE_HEADER_LENGTH;
 
@@ -97,9 +98,16 @@ public class FixPReplayerSession extends ReplayerSession
         state = State.REPLAYING;
     }
 
-    MessageTracker messageTracker()
+    void query()
     {
-        return new FixPMessageTracker(this, binaryParser, (endSeqNo - beginSeqNo) + 1);
+        replayOperation = replayQuery.query(
+            sessionId,
+            beginSeqNo,
+            sequenceIndex,
+            endSeqNo,
+            sequenceIndex,
+            REPLAY,
+            new FixPMessageTracker(this, binaryParser, (endSeqNo - beginSeqNo) + 1));
     }
 
     public boolean attemptReplay()

--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/logger/GapFiller.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/logger/GapFiller.java
@@ -115,6 +115,7 @@ public class GapFiller extends AbstractReplayer
             final int endSeqNo = (int)validResendRequest.endSequenceNumber();
             final int sequenceIndex = validResendRequest.sequenceIndex();
             final long correlationId = validResendRequest.correlationId();
+            final int overriddenBeginSeqNo = (int)validResendRequest.overriddenBeginSequenceNumber();
             validResendRequest.wrapBody(asciiBuffer);
 
             return onResendRequest(

--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/logger/GapFiller.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/logger/GapFiller.java
@@ -115,7 +115,6 @@ public class GapFiller extends AbstractReplayer
             final int endSeqNo = (int)validResendRequest.endSequenceNumber();
             final int sequenceIndex = validResendRequest.sequenceIndex();
             final long correlationId = validResendRequest.correlationId();
-            final int overriddenBeginSeqNo = (int)validResendRequest.overriddenBeginSequenceNumber();
             validResendRequest.wrapBody(asciiBuffer);
 
             return onResendRequest(

--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/logger/ReplayerSession.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/logger/ReplayerSession.java
@@ -22,8 +22,6 @@ import org.agrona.concurrent.IdleStrategy;
 import org.agrona.concurrent.status.AtomicCounter;
 import uk.co.real_logic.artio.Pressure;
 
-import static uk.co.real_logic.artio.LogTag.REPLAY;
-
 abstract class ReplayerSession implements ControlledFragmentHandler
 {
     private final int maxClaimAttempts;
@@ -77,19 +75,7 @@ abstract class ReplayerSession implements ControlledFragmentHandler
         this.bytesInBuffer = bytesInBuffer;
     }
 
-    void query()
-    {
-        replayOperation = replayQuery.query(
-            sessionId,
-            beginSeqNo,
-            sequenceIndex,
-            endSeqNo,
-            sequenceIndex,
-            REPLAY,
-            messageTracker());
-    }
-
-    abstract MessageTracker messageTracker();
+    abstract void query();
 
     boolean claimBuffer(final int newLength, final int messageLength)
     {

--- a/artio-core/src/main/java/uk/co/real_logic/artio/protocol/GatewayPublication.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/protocol/GatewayPublication.java
@@ -1370,6 +1370,32 @@ public class GatewayPublication extends ClaimablePublication
         final int bodyOffset,
         final int bodyLength)
     {
+        return saveValidResendRequest(
+            sessionId,
+            connectionId,
+            beginSequenceNumber,
+            endSequenceNumber,
+            sequenceIndex,
+            correlationId,
+            ValidResendRequestEncoder.overriddenBeginSequenceNumberNullValue(),
+            bodyBuffer,
+            bodyOffset,
+            bodyLength
+        );
+    }
+
+    public long saveValidResendRequest(
+        final long sessionId,
+        final long connectionId,
+        final long beginSequenceNumber,
+        final long endSequenceNumber,
+        final int sequenceIndex,
+        final long correlationId,
+        final long overriddenBeginSequenceNumber,
+        final DirectBuffer bodyBuffer,
+        final int bodyOffset,
+        final int bodyLength)
+    {
         final long position = claim(VALID_RESEND_REQUEST_LENGTH + bodyLength);
         if (position < 0)
         {
@@ -1387,6 +1413,7 @@ public class GatewayPublication extends ClaimablePublication
             .endSequenceNumber(endSequenceNumber)
             .sequenceIndex(sequenceIndex)
             .correlationId(correlationId)
+            .overriddenBeginSequenceNumber(overriddenBeginSequenceNumber)
             .putBody(bodyBuffer, bodyOffset, bodyLength);
 
         bufferClaim.commit();

--- a/artio-core/src/main/java/uk/co/real_logic/artio/session/ResendRequestResponse.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/session/ResendRequestResponse.java
@@ -16,11 +16,16 @@
 package uk.co.real_logic.artio.session;
 
 import uk.co.real_logic.artio.builder.AbstractRejectEncoder;
+import uk.co.real_logic.artio.dictionary.generation.CodecUtil;
+import uk.co.real_logic.artio.messages.ValidResendRequestEncoder;
 
 public class ResendRequestResponse
 {
+    public static final int USE_BEGIN_SEQ_NO = (int)ValidResendRequestEncoder.overriddenBeginSequenceNumberNullValue();
+
     private boolean result;
 
+    private int overriddenBeginSequenceNumber;
     private int refTagId;
     private AbstractRejectEncoder rejectEncoder;
 
@@ -29,6 +34,23 @@ public class ResendRequestResponse
      */
     public void resend()
     {
+        overriddenBeginSequenceNumber = USE_BEGIN_SEQ_NO;
+        refTagId = CodecUtil.MISSING_INT;
+        rejectEncoder = null;
+
+        result = true;
+    }
+
+    /**
+     * Invoke when you want to respond to the resend request, from an overridden beginSeqNum, gapfilling prior messages
+     * @param overriddenBeginSequenceNumber indicates messages before this are gapfilled
+     */
+    public void resendFrom(final int overriddenBeginSequenceNumber)
+    {
+        this.overriddenBeginSequenceNumber = overriddenBeginSequenceNumber;
+        refTagId = CodecUtil.MISSING_INT;
+        rejectEncoder = null;
+
         result = true;
     }
 
@@ -39,13 +61,17 @@ public class ResendRequestResponse
      */
     public void reject(final int refTagId)
     {
+        overriddenBeginSequenceNumber = USE_BEGIN_SEQ_NO;
         this.refTagId = refTagId;
+        rejectEncoder = null;
 
         result = false;
     }
 
     public void reject(final AbstractRejectEncoder rejectEncoder)
     {
+        overriddenBeginSequenceNumber = USE_BEGIN_SEQ_NO;
+        refTagId = CodecUtil.MISSING_INT;
         this.rejectEncoder = rejectEncoder;
 
         result = false;
@@ -59,6 +85,11 @@ public class ResendRequestResponse
     boolean result()
     {
         return result;
+    }
+
+    int overriddenBeginSequenceNumber()
+    {
+        return overriddenBeginSequenceNumber;
     }
 
     int refTagId()

--- a/artio-core/src/main/java/uk/co/real_logic/artio/session/Session.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/session/Session.java
@@ -2093,13 +2093,20 @@ public class Session
 
         if (resendRequestResponse.result())
         {
+            int overriddenBeginSeqNum = resendRequestResponse.overriddenBeginSequenceNumber();
+            if (overriddenBeginSeqNum != ResendRequestResponse.USE_BEGIN_SEQ_NO)
+            {
+                overriddenBeginSeqNum = Math.max(overriddenBeginSeqNum, beginSeqNum);
+                overriddenBeginSeqNum = Math.min(overriddenBeginSeqNum, correctedEndSeqNo);
+            }
+
             final long correlationId = generateReplayCorrelationId();
 
             // Notify the sender end point that a replay is going to happen.
             if (!backpressuredResendRequestResponse || backpressuredOutboundValidResendRequest)
             {
                 if (saveValidResendRequest(beginSeqNum, messageBuffer, messageOffset, messageLength, correctedEndSeqNo,
-                    correlationId, outboundPublication))
+                    correlationId, overriddenBeginSeqNum, outboundPublication))
                 {
                     lastReceivedMsgSeqNum(oldLastReceivedMsgSeqNum);
                     backpressuredResendRequestResponse = true;
@@ -2111,7 +2118,7 @@ public class Session
             }
 
             if (saveValidResendRequest(beginSeqNum, messageBuffer, messageOffset, messageLength, correctedEndSeqNo,
-                correlationId, inboundPublication))
+                correlationId, overriddenBeginSeqNum, inboundPublication))
             {
                 lastReceivedMsgSeqNum(oldLastReceivedMsgSeqNum);
                 backpressuredResendRequestResponse = true;
@@ -2150,7 +2157,8 @@ public class Session
 
     private boolean saveValidResendRequest(
         final int beginSeqNum, final AsciiBuffer messageBuffer, final int messageOffset, final int messageLength,
-        final int correctedEndSeqNo, final long correlationId, final GatewayPublication publication)
+        final int correctedEndSeqNo, final long correlationId, final int overriddenBeginSeqNum,
+        final GatewayPublication publication)
     {
         return Pressure.isBackPressured(publication.saveValidResendRequest(
             id,
@@ -2159,6 +2167,7 @@ public class Session
             correctedEndSeqNo,
             sequenceIndex,
             correlationId,
+            overriddenBeginSeqNum,
             messageBuffer,
             messageOffset,
             messageLength));

--- a/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/FakeResendRequestController.java
+++ b/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/FakeResendRequestController.java
@@ -31,6 +31,7 @@ public class FakeResendRequestController implements ResendRequestController
 {
     public static final String CUSTOM_MESSAGE = "custom message";
     private boolean resend = true;
+    private int overriddenBeginSeqNo = -1;
 
     private int callCount = 0;
     private IntArrayList seenReplaysInFlight = new IntArrayList();
@@ -53,7 +54,14 @@ public class FakeResendRequestController implements ResendRequestController
 
         if (resend)
         {
-            response.resend();
+            if (overriddenBeginSeqNo != -1)
+            {
+                response.resendFrom(overriddenBeginSeqNo);
+            }
+            else
+            {
+                response.resend();
+            }
         }
         else if (customResend)
         {
@@ -80,6 +88,11 @@ public class FakeResendRequestController implements ResendRequestController
     public void resend(final boolean resend)
     {
         this.resend = resend;
+    }
+
+    public void overriddenBeginSeqNo(final int overriddenBeginSeqNo)
+    {
+        this.overriddenBeginSeqNo = overriddenBeginSeqNo;
     }
 
     public void maxResends(final int maxResends)

--- a/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/GatewayToGatewaySystemTest.java
+++ b/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/GatewayToGatewaySystemTest.java
@@ -389,8 +389,8 @@ public class GatewayToGatewaySystemTest extends AbstractGatewayToGatewaySystemTe
 
         testSystem.await("Failed to receive messages", () ->
         {
-            final long totalRececeivedMessages = acceptingOtfAcceptor.messages().size();
-            return totalRececeivedMessages >= 10;
+            final long totalReceivedMessages = acceptingOtfAcceptor.messages().size();
+            return totalReceivedMessages >= 10;
         });
 
         acceptingOtfAcceptor.messages().clear();
@@ -399,9 +399,9 @@ public class GatewayToGatewaySystemTest extends AbstractGatewayToGatewaySystemTe
 
         testSystem.await("Failed to receive resent messages", () ->
         {
-            final long totalRececeivedMessages = acceptingOtfAcceptor.messages().size();
+            final long totalReceivedMessages = acceptingOtfAcceptor.messages().size();
 
-            if (totalRececeivedMessages < 3)
+            if (totalReceivedMessages < 3)
             {
                 return false;
             }

--- a/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/GatewayToGatewaySystemTest.java
+++ b/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/GatewayToGatewaySystemTest.java
@@ -389,8 +389,8 @@ public class GatewayToGatewaySystemTest extends AbstractGatewayToGatewaySystemTe
 
         testSystem.await("Failed to receive messages", () ->
         {
-            final long totalReplayedMessages = acceptingOtfAcceptor.messages().size();
-            return totalReplayedMessages >= 10;
+            final long totalRececeivedMessages = acceptingOtfAcceptor.messages().size();
+            return totalRececeivedMessages >= 10;
         });
 
         acceptingOtfAcceptor.messages().clear();
@@ -399,24 +399,30 @@ public class GatewayToGatewaySystemTest extends AbstractGatewayToGatewaySystemTe
 
         testSystem.await("Failed to receive resent messages", () ->
         {
-            final long totalReplayedMessages = acceptingOtfAcceptor.messages().size();
+            final long totalRececeivedMessages = acceptingOtfAcceptor.messages().size();
 
-            if (totalReplayedMessages < 3)
+            if (totalRececeivedMessages < 3)
             {
                 return false;
             }
             else
             {
                 final List<FixMessage> fixMessageList = acceptingOtfAcceptor.messages();
+
                 final FixMessage gapFill = fixMessageList.get(0);
                 assertEquals(SEQUENCE_RESET_MESSAGE, gapFill.messageType());
                 assertEquals(1, gapFill.messageSequenceNumber());
+                assertEquals("Y", gapFill.gapFill());
+                assertEquals(10, gapFill.getInt(Constants.NEW_SEQ_NO));
+
                 final FixMessage executionReportNine = fixMessageList.get(1);
                 assertEquals(EXECUTION_REPORT_MESSAGE, executionReportNine.messageType());
                 assertEquals(10, executionReportNine.messageSequenceNumber());
+
                 final FixMessage executionReportTen = fixMessageList.get(2);
                 assertEquals(EXECUTION_REPORT_MESSAGE, executionReportTen.messageType());
                 assertEquals(11, executionReportTen.messageSequenceNumber());
+
                 return true;
             }
         });

--- a/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/GatewayToGatewaySystemTest.java
+++ b/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/GatewayToGatewaySystemTest.java
@@ -373,6 +373,57 @@ public class GatewayToGatewaySystemTest extends AbstractGatewayToGatewaySystemTe
         assertEquals(2, fakeResendRequestController.callCount());
     }
 
+    @Test(timeout = TEST_TIMEOUT_IN_MS)
+    public void shouldControlResendRequestsWithOverriddenBeginSeqNo()
+    {
+        fakeResendRequestController.maxResends(1);
+        fakeResendRequestController.resend(true);
+        fakeResendRequestController.overriddenBeginSeqNo(10);
+
+        acquireAcceptingSession();
+
+        for (int i = 0; i < 10; i++)
+        {
+            exchangeExecutionReport(initiatingSession, acceptingOtfAcceptor);
+        }
+
+        testSystem.await("Failed to receive messages", () ->
+        {
+            final long totalReplayedMessages = acceptingOtfAcceptor.messages().size();
+            return totalReplayedMessages >= 10;
+        });
+
+        acceptingOtfAcceptor.messages().clear();
+
+        acceptorSendsResendRequest(1, 0);
+
+        testSystem.await("Failed to receive resent messages", () ->
+        {
+            final long totalReplayedMessages = acceptingOtfAcceptor.messages().size();
+
+            if (totalReplayedMessages < 3)
+            {
+                return false;
+            }
+            else
+            {
+                final List<FixMessage> fixMessageList = acceptingOtfAcceptor.messages();
+                final FixMessage gapFill = fixMessageList.get(0);
+                assertEquals(SEQUENCE_RESET_MESSAGE, gapFill.messageType());
+                assertEquals(1, gapFill.messageSequenceNumber());
+                final FixMessage executionReportNine = fixMessageList.get(1);
+                assertEquals(EXECUTION_REPORT_MESSAGE, executionReportNine.messageType());
+                assertEquals(10, executionReportNine.messageSequenceNumber());
+                final FixMessage executionReportTen = fixMessageList.get(2);
+                assertEquals(EXECUTION_REPORT_MESSAGE, executionReportTen.messageType());
+                assertEquals(11, executionReportTen.messageSequenceNumber());
+                return true;
+            }
+        });
+
+        assertEquals(1, fakeResendRequestController.callCount());
+    }
+
     // Test exists to replicate a faily complex bug involving a sequence number issue after a library timeout.
     @Test(timeout = TEST_TIMEOUT_IN_MS)
     public void shouldNotSendDuplicateSequenceNumbersAfterTimeout()


### PR DESCRIPTION
This allows users more control over responding to resend requests by allowing user to programatically decide from what sequence number they would like to replay, gapfilling prior messages.